### PR TITLE
Bug, listeners, related video query updates

### DIFF
--- a/ApiClient.java
+++ b/ApiClient.java
@@ -1,0 +1,21 @@
+package com.exoplayer.exoplayerapp;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+// CREATES THE RETROFIT INSTANCE
+
+public class ApiClient {
+    public static String BASE_URL ="https://images-api.nasa.gov/";
+    private static Retrofit retrofit;
+    public static Retrofit getClient(OkHttpClient okHttpClient){
+        if(retrofit == null){
+            retrofit = new Retrofit.Builder()
+                    .baseUrl(BASE_URL)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build();
+        }
+        return retrofit;
+    }
+}

--- a/MainActivity.java
+++ b/MainActivity.java
@@ -1,0 +1,91 @@
+package com.exoplayer.exoplayerapp;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class MainActivity extends AppCompatActivity  {
+    Collection movieList;
+    RecyclerView recyclerView;
+    RecyclerAdapter recyclerAdapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        recyclerView = (RecyclerView)findViewById(R.id.recyclerview);
+        LinearLayoutManager layoutManager = new LinearLayoutManager(this);
+        recyclerView.setLayoutManager(layoutManager);
+        recyclerAdapter = new RecyclerAdapter(getApplicationContext(),movieList);
+        recyclerView.setAdapter(recyclerAdapter);
+
+
+        OkHttpClient okHttpClient = new OkHttpClient().newBuilder().addInterceptor(new Interceptor() {
+            @Override public okhttp3.Response intercept(Interceptor.Chain chain) throws IOException {
+                Request originalRequest = chain.request();
+                Request.Builder builder = originalRequest.newBuilder();
+                Request newRequest = builder.build();
+                return chain.proceed(newRequest);
+            }
+        }).build();
+
+        //
+        ApiInterface apiService = ApiClient.getClient(okHttpClient).create(ApiInterface.class);
+        searchVideos(apiService, "apollo");
+
+        final EditText ET = (EditText) findViewById(R.id.searchbartextView);
+        Button button = (Button) findViewById(R.id.searchButton);
+        button.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                String searchTerm = ET.getText().toString();
+                searchVideos(apiService, searchTerm);
+            }
+        });
+
+    }
+
+    public void searchVideos(ApiInterface a, String s) {
+        Call<Collection> call = a.getMovies(s, "video");
+
+        call.enqueue(new Callback<Collection>() {
+            @Override
+            public void onResponse(Call<Collection> call, Response<Collection> response) {
+                if (response.isSuccessful()) {
+                    movieList = response.body();
+
+                    //if search results are empty, toast notification prompts
+                    // user to try another search
+                    if(movieList.getCollection().getItems().isEmpty()) {
+                        Toast.makeText(MainActivity.this, "No results for '" + s + ",' try another keyword search.", Toast.LENGTH_LONG).show();
+                    }
+
+                    //recyclerAdapter is set with contents of movieList collection
+                    recyclerAdapter.setMovieList(movieList);
+
+                }
+            }
+
+            @Override
+            public void onFailure(Call<Collection> call, Throwable t) {
+                Log.d("TAG","Response = "+t.toString());
+            }
+
+        });
+    }
+}

--- a/PlayerActivity.kt
+++ b/PlayerActivity.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package com.exoplayer.exoplayerapp
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.Util
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.exoplayer.exoplayerapp.databinding.ActivityPlayerBinding
+import okhttp3.OkHttpClient
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+
+//TODO: Add intents for new activity and send url string
+/**
+ * A fullscreen activity to play audio or video streams.
+ */
+class PlayerActivity : AppCompatActivity() {
+
+    private var player: ExoPlayer? = null
+    private var playWhenReady = true
+    private var currentItem = 0
+    private var playbackPosition = 0L
+    lateinit var url: String
+    lateinit var keyword: String
+    lateinit var desc: String
+    lateinit var title: String
+    var movieList: Collection? = null
+    lateinit var recyclerView: RecyclerView
+    lateinit var recyclerAdapter: RecyclerAdapter
+
+    //lazy(..) is a kotlin delegate for lazy initializing a value the first time it is used.
+    private val viewBinding by lazy(LazyThreadSafetyMode.NONE) {
+        ActivityPlayerBinding.inflate(layoutInflater)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(viewBinding.root)
+        url = intent.getStringExtra("url").toString()
+        keyword = intent.getStringExtra("keywords").toString()
+        desc = intent.getStringExtra("desc").toString()
+        title = intent.getStringExtra("title").toString()
+
+        viewBinding.exoDescription.setText(desc)
+
+        if (viewBinding.exoDescription.text.length > 300) {
+
+            viewBinding.seeMore.visibility = View.VISIBLE;
+
+            val seeMore = viewBinding.seeMore as TextView
+            seeMore.setOnClickListener {
+                viewBinding.exoDescription.maxLines = 30;
+            }
+        }
+
+        viewBinding.exoTitle.setText(title)
+
+        val layoutManager = LinearLayoutManager(this)
+        viewBinding.recyclerview.setLayoutManager(layoutManager)
+        recyclerAdapter = RecyclerAdapter(applicationContext, movieList)
+        viewBinding.recyclerview.setAdapter(recyclerAdapter)
+
+        val okHttpClient = OkHttpClient().newBuilder().addInterceptor { chain ->
+            val originalRequest = chain.request()
+            val builder = originalRequest.newBuilder()
+            val newRequest = builder.build()
+            chain.proceed(newRequest)
+        }.build()
+
+        val apiService = ApiClient.getClient(okHttpClient).create(
+            ApiInterface::class.java
+        )
+
+        Log.d("Playerkeywords!!!!!!!!!", keyword)
+        val call = apiService.getMovies(keyword, "video")
+
+        call.enqueue(object : Callback<Collection?> {
+            override fun onResponse(call: Call<Collection?>, response: Response<Collection?>) {
+                if (response.isSuccessful) {
+                    movieList = response.body()!!
+                    Log.d("TAG",
+                        "Response = we did it johnny"
+                    )
+                    recyclerAdapter.setMovieList(movieList)
+                }
+            }
+
+
+
+            override fun onFailure(call: Call<Collection?>, t: Throwable) {
+                Log.d("TAG", "Response = $t")
+            }
+        })
+    }
+
+    private fun initializePlayer() {
+        player = ExoPlayer.Builder(this)
+                .build()
+                .also { exoPlayer ->
+                    viewBinding.videoView.player = exoPlayer
+                    val mediaItem =
+                        MediaItem.fromUri(url)//the content to play sourced from strings.xml
+                    exoPlayer.setMediaItem(mediaItem)
+                    exoPlayer.playWhenReady =
+                        playWhenReady //playWhenReady tells the player whether to start playing as soon as all resources for playback have been acquired.
+                    exoPlayer.seekTo(
+                        currentItem,
+                        playbackPosition
+                    ) //seekTo tells the player to seek to a certain position within a specific media item.
+                    exoPlayer.prepare() //prepare tells the player to acquire all the resources required for playback
+                }
+    }
+
+    public override fun onStart() {
+        super.onStart()
+        if (Util.SDK_INT > 23) {
+            initializePlayer()
+        }
+    }
+
+    public override fun onResume() {
+        super.onResume()
+        hideSystemUi()
+        if ((Util.SDK_INT <= 23 || player == null)) {
+            initializePlayer()
+        }
+    }
+
+    @SuppressLint("InlinedApi")
+    private fun hideSystemUi() {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        WindowInsetsControllerCompat(window, viewBinding.videoView).let { controller ->
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+    }
+
+    public override fun onPause() {
+        super.onPause()
+        if (Util.SDK_INT <= 23) {
+            releasePlayer()
+        }
+    }
+
+
+    public override fun onStop() {
+        super.onStop()
+        if (Util.SDK_INT > 23) {
+            releasePlayer()
+        }
+    }
+
+    private fun releasePlayer() {
+        player?.let { exoPlayer ->
+            playbackPosition = exoPlayer.currentPosition
+            currentItem = exoPlayer.currentMediaItemIndex
+            playWhenReady = exoPlayer.playWhenReady
+            exoPlayer.release()
+        }
+        player = null
+    }
+}

--- a/RecyclerAdapter.java
+++ b/RecyclerAdapter.java
@@ -1,0 +1,132 @@
+package com.exoplayer.exoplayerapp;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.RequestOptions;
+
+public class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.MyviewHolder>  {
+
+    Context context;
+    Collection movieList;
+
+    public RecyclerAdapter(Context context, Collection movieList) {
+        this.context = context;
+        this.movieList = movieList;
+
+    }
+
+    public void setMovieList(Collection movieList) {
+        this.movieList = movieList;
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public RecyclerAdapter.MyviewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(context).inflate(R.layout.recyclerview_adapter,parent,false);
+        return new MyviewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(RecyclerAdapter.MyviewHolder holder, int position) {
+
+        //Video Title
+        holder.tvMovieName.setText(movieList.getCollection().getItems().get(position).getData().get(0).getTitle());
+        System.out.println(movieList.getCollection().getItems().get(position).getData().get(0).getTitle());
+
+        //Video Thumbnail Image
+        Glide.with(context).load(movieList.getCollection().getItems().get(position).getLinks().get(0).getHref()).apply(RequestOptions.centerCropTransform()).into(holder.image);
+        System.out.println(movieList.getCollection().getItems().get(position).getLinks().get(0).getHref());
+
+        //Video Creation Date
+        holder.dataCreated.setText("Date: " + movieList.getCollection().getItems().get(position).getData().get(0).getDateCreated().substring(0,10));
+
+        //Video URL
+        String videoURL = "https://images-assets.nasa.gov/video/" + movieList.getCollection().getItems().get(position).getData().get(0).getNasaId() + "/" + movieList.getCollection().getItems().get(position).getData().get(0).getNasaId() + "~orig.mp4";
+
+        //Video Title
+        String videoTitle = movieList.getCollection().getItems().get(position).getData().get(0).getTitle();
+
+        //Video Description
+        String videoDescription = movieList.getCollection().getItems().get(position).getData().get(0).getDescription();
+        holder.desc.setText(movieList.getCollection().getItems().get(position).getData().get(0).getDescription());
+
+        //Video keywords
+        String keywords = "James Webb";
+        if(movieList.getCollection().getItems().get(position).getData().get(0).getKeywords() != null) {
+            keywords = movieList.getCollection().getItems().get(position).getData().get(0).getKeywords().get(0);
+        }
+        String finalKeywords = keywords;
+        Log.d("keywords!!!!!!!!!", finalKeywords);
+
+        //onClickListeners for title
+        holder.tvMovieName.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                System.out.println("button clicked");
+                Intent intent = new Intent(context, PlayerActivity.class);
+                intent.putExtra("url", videoURL);
+                Log.d("videourl", videoURL);
+                intent.putExtra("desc", videoDescription);
+                intent.putExtra("keywords", finalKeywords);
+                intent.putExtra("title", videoTitle);
+
+                context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+            }
+        });
+
+        //onClickListeners for thumbnail image
+        holder.image.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                System.out.println("button clicked");
+                Intent intent = new Intent(context, PlayerActivity.class);
+                intent.putExtra("url", videoURL);
+                Log.d("videourl", videoURL);
+                intent.putExtra("desc", videoDescription);
+                intent.putExtra("keywords", finalKeywords);
+                intent.putExtra("title", videoTitle);
+
+                context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
+            }
+        });
+
+    }
+
+    @Override
+    public int getItemCount() {
+        if(movieList != null){
+            return movieList.getCollection().getMetadata().getTotalHits();
+        }
+        return 0;
+    }
+
+    public class MyviewHolder extends RecyclerView.ViewHolder {
+        TextView tvMovieName;
+        ImageView image;
+        TextView dataCreated;
+        TextView desc;
+
+        public MyviewHolder(View itemView) {
+            super(itemView);
+            tvMovieName = (TextView)itemView.findViewById(R.id.title);
+            image = (ImageView)itemView.findViewById(R.id.image);
+            dataCreated = (TextView)itemView.findViewById(R.id.videoDate);
+            desc = (TextView) itemView.findViewById(R.id.description);
+        }
+    }
+
+}
+
+
+


### PR DESCRIPTION
NEW:
  - Fixed bug: app crashed if collection was empty. Added conditional handler and toast notification if results are empty.
  - Added onClickListener to image on search results
  - Added an expandable textview section for description under video.
  - Used keywords of selected video as query for 'related videos' section
  
 TODO:
  - Add loading image when user first opens app
  - Figure out if black ExoPlayer screen that appears when ExoPlayer activity is loaded can be removed
  - Improve search bar functionality (autocomplete, etc using Google search dialogue)
  - Add Home button
  - Make See More link expansion retractable